### PR TITLE
changes made to peer-channel-state

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1279,6 +1279,7 @@ static void json_peer_channel_state(struct command *cmd, const char *buffer,
 					{
 					case (SQLITE_INTEGER):
 						json_object_start(response,NULL);
+						channel_state=sqlite3_column_int(stmt1, i);
 						json_add_num(response, "channel-state", channel_state);
 						json_object_end(response);
 						break;

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1266,7 +1266,7 @@ static void json_peer_channel_state(struct command *cmd, const char *buffer,
 	else
 	{
 		
-			stmt1 = db_prepare(cmd->ld->wallet->db,"SELECT state FROM channels WHERE id IN (SELECT id, FROM peers WHERE lower(hex(node_id))=?);");
+			stmt1 = db_prepare(cmd->ld->wallet->db,"SELECT state FROM channels WHERE peer_id IN (SELECT id FROM peers WHERE lower(hex(node_id))=?);");
 			sqlite3_bind_text(stmt1, 1, buf, strlen(buf), SQLITE_TRANSIENT);
 			
 			while (sqlite3_step(stmt1) == SQLITE_ROW) {

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1269,7 +1269,7 @@ static void json_peer_channel_state(struct command *cmd, const char *buffer,
 			stmt1 = db_prepare(cmd->ld->wallet->db,"SELECT state FROM channels WHERE id IN (SELECT id, FROM peers WHERE lower(hex(node_id))=?);");
 			sqlite3_bind_text(stmt1, 1, buf, strlen(buf), SQLITE_TRANSIENT);
 			
-			while (sqlite3_step(stmt) == SQLITE_ROW) {
+			while (sqlite3_step(stmt1) == SQLITE_ROW) {
 				int i;
 				int num_cols = sqlite3_column_count(stmt1);
 				

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1219,8 +1219,8 @@ static void json_peer_channel_state(struct command *cmd, const char *buffer,
 	struct json_result *response = new_json_result(cmd);
 	jsmntok_t *idtok;
 	char buf[100];
-	sqlite3_stmt *stmt;
-	int channel_state=-1;
+	sqlite3_stmt *stmt,*stmt1;
+	int channel_state=-1,peer_exits;
 	if (!json_get_params(cmd, buffer, params,
 			     "id", &idtok,
 			     NULL)) {
@@ -1228,15 +1228,17 @@ static void json_peer_channel_state(struct command *cmd, const char *buffer,
 	}
 	memcpy(buf,buffer + idtok->start,idtok->end - idtok->start);
 	buf[idtok->end - idtok->start]='\0';
-	stmt = db_prepare(cmd->ld->wallet->db,
+	/*stmt = db_prepare(cmd->ld->wallet->db,
 						  "SELECT COALESCE(sum(state),0)"
 						  " FROM channels"
 						  " Where id IN "
 						  " (SELECT COALESCE(sum(id),0)"
 						  "  FROM peers"
-						  "  WHERE lower(hex(node_id))=?);");
+						  "  WHERE lower(hex(node_id))=?);");*/
+	stmt = db_prepare(cmd->ld->wallet->db,"SELECT count(*) FROM peers WHERE lower(hex(node_id))=?;");
 	sqlite3_bind_text(stmt, 1, buf, strlen(buf), SQLITE_TRANSIENT);
-	while (sqlite3_step(stmt) != SQLITE_DONE) {
+	
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
 		int i;
 		int num_cols = sqlite3_column_count(stmt);
 		
@@ -1244,14 +1246,8 @@ static void json_peer_channel_state(struct command *cmd, const char *buffer,
 		{
 			switch (sqlite3_column_type(stmt, i))
 			{
-			case (SQLITE3_TEXT):
-				printf("%s, ", sqlite3_column_text(stmt, i));
-				break;
 			case (SQLITE_INTEGER):
-				channel_state=sqlite3_column_int(stmt, i);
-				break;
-			case (SQLITE_FLOAT):
-				printf("%g, ", sqlite3_column_double(stmt, i));
+				peer_exits=sqlite3_column_int(stmt, i);
 				break;
 			default:
 				break;
@@ -1260,7 +1256,41 @@ static void json_peer_channel_state(struct command *cmd, const char *buffer,
 	}
 	sqlite3_finalize(stmt);
 	json_object_start(response, NULL);
-	json_add_num(response, "channel-state", channel_state);
+	json_array_start(response,"channel-states");
+	if(peer_exits != 0)
+	{
+		json_object_start(response,NULL);
+		json_add_num(response, "channel-state", channel_state);
+		json_object_end(response);
+	}
+	else
+	{
+		
+			stmt1 = db_prepare(cmd->ld->wallet->db,"SELECT state FROM channels WHERE id IN (SELECT id, FROM peers WHERE lower(hex(node_id))=?);");
+			sqlite3_bind_text(stmt1, 1, buf, strlen(buf), SQLITE_TRANSIENT);
+			
+			while (sqlite3_step(stmt) == SQLITE_ROW) {
+				int i;
+				int num_cols = sqlite3_column_count(stmt1);
+				
+				for (i = 0; i < num_cols; i++)
+				{
+					switch (sqlite3_column_type(stmt1, i))
+					{
+					case (SQLITE_INTEGER):
+						json_object_start(response,NULL);
+						json_add_num(response, "channel-state", channel_state);
+						json_object_end(response);
+						break;
+					default:
+						break;
+					}
+				}
+			}
+			sqlite3_finalize(stmt1);
+		
+	}
+	json_array_end(response);
 	json_object_end(response);
 	command_success(cmd, response);
 }

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1257,10 +1257,10 @@ static void json_peer_channel_state(struct command *cmd, const char *buffer,
 	sqlite3_finalize(stmt);
 	json_object_start(response, NULL);
 	json_array_start(response,"channel-states");
-	if(peer_exits != 0)
+	if(peer_exits == 0)
 	{
 		json_object_start(response,NULL);
-		json_add_num(response, "channel-state", channel_state);
+		json_add_num(response, "channel-state", 0);
 		json_object_end(response);
 	}
 	else


### PR DESCRIPTION
In some scenarios, when the channel is closed, it take 100 block confirmations to get it removed from DB. In such scenarios LN allows to establish a new channel, two handle these two channel state(one is closing state and the other one in opening state) the changes made in this pull request.